### PR TITLE
Fix unit test parsing and refresh verification evidence

### DIFF
--- a/REALITY_CHECKLIST.txt
+++ b/REALITY_CHECKLIST.txt
@@ -1,7 +1,5 @@
 # Reality Checklist
-- [x] F1 — Hero kicker proclaims “AXIOM PROTOCOL ONLINE” status (VERIFIED)
-- [x] F2 — Ultimate AI Agent — Production-Ready Edition appears in project showcase (VERIFIED)
-- [x] F3 — Lab streams list the Security Drills feed (VERIFIED)
-- [x] F4 — Topic showcase exposes accessible tablist controls (VERIFIED)
-- [x] F5 — Contact form button invites visitors to “Initiate contact” (VERIFIED)
-- [x] F6 — Production build compiles via `CI=1 npx --no-install next build` (VERIFIED)
+- [x] F1 — Static export build yields Next.js route summary (VERIFIED)
+- [x] F2 — ESLint run reports no issues (VERIFIED)
+- [x] F3 — Custom unit test runner reports zero failed tests (VERIFIED)
+- [x] F4 — Bundle regression guard stays within baseline threshold (VERIFIED)

--- a/evidence/F1-build-static.txt
+++ b/evidence/F1-build-static.txt
@@ -1,0 +1,53 @@
+
+> ultimate-dynamic-portfolio@0.1.0 build:static
+> node scripts/exclude-api-routes.js clean && npm run typecheck && node scripts/exclude-api-routes.js move && NEXT_EXPORT=true NEXT_SKIP_TYPE_CHECK=1 NEXT_DISABLE_SWC_BINARY=1 next build && node scripts/exclude-api-routes.js restore
+
+✅ Cleaned .next
+✅ Cleaned out
+
+> ultimate-dynamic-portfolio@0.1.0 typecheck
+> tsc --noEmit
+
+Attention: Next.js now collects completely anonymous telemetry regarding usage.
+This information is used to shape Next.js' roadmap and prioritize features.
+You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
+https://nextjs.org/telemetry
+
+   ▲ Next.js 15.5.4
+
+   Creating an optimized production build ...
+ ✓ Compiled successfully in 12.4s
+   Linting and checking validity of types ...
+   Collecting page data ...
+   Generating static pages (0/12) ...
+   Generating static pages (3/12) 
+   Generating static pages (6/12) 
+   Generating static pages (9/12) 
+ ✓ Generating static pages (12/12)
+   Finalizing page optimization ...
+   Collecting build traces ...
+   Exporting (0/2) ...
+ ✓ Exporting (2/2)
+
+Route (app)                                 Size  First Load JS
+┌ ○ /                                    53.8 kB         201 kB
+├ ○ /_not-found                            991 B         103 kB
+├ ○ /admin                               5.32 kB         144 kB
+├ ○ /blog                                40.6 kB         183 kB
+├ ● /projects/[slug]                       165 B         105 kB
+├   ├ /projects/ultimate-ai-agent
+├   ├ /projects/multimedia-pipeline
+├   ├ /projects/cybersecurity-home-lab
+├   └ [+2 more paths]
+└ ○ /resume                                165 B         105 kB
++ First Load JS shared by all             102 kB
+  ├ chunks/255-bb8f17202d2aafcd.js       45.5 kB
+  ├ chunks/4bd1b696-21f374d1156f834a.js  54.2 kB
+  └ other shared chunks (total)          1.96 kB
+
+
+ƒ Middleware                             34.3 kB
+
+○  (Static)  prerendered as static content
+●  (SSG)     prerendered as static HTML (uses generateStaticParams)
+

--- a/evidence/F2-lint.txt
+++ b/evidence/F2-lint.txt
@@ -1,0 +1,4 @@
+
+> ultimate-dynamic-portfolio@0.1.0 lint
+> eslint .
+

--- a/evidence/F3-unit-tests.txt
+++ b/evidence/F3-unit-tests.txt
@@ -1,0 +1,14 @@
+
+> ultimate-dynamic-portfolio@0.1.0 test:unit
+> node scripts/run-unit-tests.mjs
+
+🔍 [2025-10-01T17:26:41.327Z] Starting enhanced test runner...
+    { coverage: false, filters: 'none', workers: 4 }
+🔍 [2025-10-01T17:26:41.342Z] Building 2 test files...
+    { workers: 4, target: 'node20' }
+✅ [2025-10-01T17:26:41.397Z] Test compilation completed
+🔍 [2025-10-01T17:26:41.398Z] Executing 2 test files...
+🔍 [2025-10-01T17:26:41.719Z] Test Summary
+    { total: 4, passed: 4, failed: 0, duration: '387ms', success: true }
+✅ [2025-10-01T17:26:41.720Z] All tests passed!
+    { total: 4, duration: '387ms' }

--- a/evidence/F4-bundle-check.txt
+++ b/evidence/F4-bundle-check.txt
@@ -1,0 +1,12 @@
+
+> ultimate-dynamic-portfolio@0.1.0 check:bundle
+> tsx scripts/check-bundle.ts
+
+┌───────────────┬────────┐
+│ (index)       │ Values │
+├───────────────┼────────┤
+│ totalBytes    │ 348374 │
+│ baselineBytes │ 348374 │
+│ delta         │ 0      │
+│ deltaPercent  │ 0      │
+└───────────────┴────────┘

--- a/features.json
+++ b/features.json
@@ -1,38 +1,26 @@
 [
   {
     "id": "F1",
-    "feature": "Hero kicker proclaims AXIOM PROTOCOL ONLINE status.",
-    "command": "rg \"AXIOM PROTOCOL ONLINE\" content/site-data.ts",
-    "expected_signal": "Output shows the hero kicker string set to AXIOM PROTOCOL ONLINE."
+    "feature": "Static export build succeeds for GitHub Pages deployment.",
+    "command": "npm run build:static",
+    "expected_signal": "Command finishes with Next.js route summary showing all pages exported."
   },
   {
     "id": "F2",
-    "feature": "Project showcase lists the Ultimate AI Agent — Production-Ready Edition case study.",
-    "command": "rg \"Ultimate AI Agent — Production-Ready Edition\" content/site-data.ts",
-    "expected_signal": "Result reveals the Ultimate AI Agent project title inside the showcase configuration."
+    "feature": "Repository passes ESLint quality gate.",
+    "command": "npm run lint",
+    "expected_signal": "eslint . completes without reporting errors or warnings."
   },
   {
     "id": "F3",
-    "feature": "Lab streams include the Security Drills log feed.",
-    "command": "rg \"Security Drills\" content/site-data.ts",
-    "expected_signal": "Search output confirms the Security Drills lab stream entry."
+    "feature": "Custom unit test runner reports all tests passing.",
+    "command": "npm run test:unit",
+    "expected_signal": "Test Summary indicates zero failed tests and All tests passed message."
   },
   {
     "id": "F4",
-    "feature": "Topic showcase renders accessible tablist controls.",
-    "command": "rg \"role=\\\"tablist\\\"\" components/TopicShowcase.tsx",
-    "expected_signal": "Component source includes a div with role=\"tablist\" labelling the topic filters."
-  },
-  {
-    "id": "F5",
-    "feature": "Contact form primary action invites visitors to Initiate contact.",
-    "command": "rg \"Initiate contact\" app/page.tsx",
-    "expected_signal": "Output contains the Initiate contact button label within the contact form actions."
-  },
-  {
-    "id": "F6",
-    "feature": "Production build compiles via CI=1 npx --no-install next build.",
-    "command": "CI=1 npx --no-install next build",
-    "expected_signal": "Command completes without module resolution, type checking, or prerender errors."
+    "feature": "Bundle regression guard validates root main chunk size against baseline.",
+    "command": "npm run check:bundle",
+    "expected_signal": "Console table shows deltaPercent within configured threshold and no error is thrown."
   }
 ]

--- a/fixes/001-runner-parse.patch
+++ b/fixes/001-runner-parse.patch
@@ -1,0 +1,65 @@
+diff --git a/scripts/run-unit-tests.mjs b/scripts/run-unit-tests.mjs
+index 55dc4f0..43f28d9 100755
+--- a/scripts/run-unit-tests.mjs
++++ b/scripts/run-unit-tests.mjs
+@@ -180,18 +180,56 @@ class TestRunner {
+ 
+   parseTestResults(stdout, stderr) {
+     const lines = stdout.split('\n')
+-    let testCount = 0
++    let testsFromSummary = false
+     let passCount = 0
+     let failCount = 0
++    let testCount = 0
++
++    for (const rawLine of lines) {
++      const line = rawLine.trim()
++
++      const summaryMatch = line.match(/^#\s+(tests|pass|fail)\s+(\d+)/i)
++      if (summaryMatch) {
++        testsFromSummary = true
++        const [, key, value] = summaryMatch
++        const count = Number.parseInt(value, 10) || 0
++        if (key.toLowerCase() === 'tests') {
++          testCount = count
++        } else if (key.toLowerCase() === 'pass') {
++          passCount = count
++        } else if (key.toLowerCase() === 'fail') {
++          failCount = count
++        }
++        continue
++      }
+ 
+-    for (const line of lines) {
+-      if (line.includes('✓') || line.includes('pass')) {
++      if (line.startsWith('ok ')) {
+         passCount++
+         testCount++
+-      } else if (line.includes('✗') || line.includes('fail')) {
++        continue
++      }
++
++      if (line.startsWith('not ok')) {
+         failCount++
+         testCount++
++        continue
+       }
++
++      if (line.startsWith('✓ ')) {
++        passCount++
++        testCount++
++        continue
++      }
++
++      if (line.startsWith('✗ ')) {
++        failCount++
++        testCount++
++        continue
++      }
++    }
++
++    if (testsFromSummary && testCount === 0) {
++      testCount = passCount + failCount
+     }
+ 
+     this.results.total = testCount

--- a/scripts/run-unit-tests.mjs
+++ b/scripts/run-unit-tests.mjs
@@ -180,18 +180,56 @@ class TestRunner {
 
   parseTestResults(stdout, stderr) {
     const lines = stdout.split('\n')
-    let testCount = 0
+    let testsFromSummary = false
     let passCount = 0
     let failCount = 0
+    let testCount = 0
 
-    for (const line of lines) {
-      if (line.includes('✓') || line.includes('pass')) {
+    for (const rawLine of lines) {
+      const line = rawLine.trim()
+
+      const summaryMatch = line.match(/^#\s+(tests|pass|fail)\s+(\d+)/i)
+      if (summaryMatch) {
+        testsFromSummary = true
+        const [, key, value] = summaryMatch
+        const count = Number.parseInt(value, 10) || 0
+        if (key.toLowerCase() === 'tests') {
+          testCount = count
+        } else if (key.toLowerCase() === 'pass') {
+          passCount = count
+        } else if (key.toLowerCase() === 'fail') {
+          failCount = count
+        }
+        continue
+      }
+
+      if (line.startsWith('ok ')) {
         passCount++
         testCount++
-      } else if (line.includes('✗') || line.includes('fail')) {
+        continue
+      }
+
+      if (line.startsWith('not ok')) {
         failCount++
         testCount++
+        continue
       }
+
+      if (line.startsWith('✓ ')) {
+        passCount++
+        testCount++
+        continue
+      }
+
+      if (line.startsWith('✗ ')) {
+        failCount++
+        testCount++
+        continue
+      }
+    }
+
+    if (testsFromSummary && testCount === 0) {
+      testCount = passCount + failCount
     }
 
     this.results.total = testCount

--- a/sha256sums.txt
+++ b/sha256sums.txt
@@ -1,0 +1,4 @@
+e49412c371b5acd163f211dccf390f72a080aac7532e7ef87824880acf1f5435  evidence/F1-build-static.txt
+ad0217d285dc87c892a6182c25a2894060a57772edb7c13317bbcf69062c41c9  evidence/F2-lint.txt
+e109b1f01488316da8ee8cab40ffa243e00f68d59c8eedb182d80bbe903c0528  evidence/F3-unit-tests.txt
+96d42f906e589baefee17d06eb754aad6dc18824a3afe67b3b4253e06c497b84  evidence/F4-bundle-check.txt


### PR DESCRIPTION
## Summary
- harden the custom unit test parser to read TAP summaries without counting "fail 0" lines as failures
- refresh reality checklist and feature inventory to cover build, lint, unit tests, and bundle regression guard
- capture command outputs as evidence with checksums for reproducible verification

## Testing
- npm run build:static
- npm run lint
- npm run test:unit
- npm run check:bundle

------
https://chatgpt.com/codex/tasks/task_b_68dd62771af88320b78096503911fa44